### PR TITLE
bug fix : enum without name & add --version option

### DIFF
--- a/src/hpp2plantuml/hpp2plantuml.py
+++ b/src/hpp2plantuml/hpp2plantuml.py
@@ -483,7 +483,7 @@ class Enum(Container):
         header_enum : CppEnum
             Parsed CppEnum object
         """
-        super().__init__('enum', header_enum['name'])
+        super().__init__('enum', header_enum.get('name','empty'))
         self.parse_members(header_enum)
 
     def parse_members(self, header_enum):
@@ -1105,6 +1105,7 @@ def main():
                         action='append', metavar='HEADER-FILE', required=True,
                         help='Input file (must be quoted' +
                         ' when using wildcards)')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.3')
     args = parser.parse_args()
     if len(args.input_files) > 0:
         CreatePlantUMLFile(args.input_files, args.output_file)


### PR DESCRIPTION
# Additional function : --version
- add --version arguments in command line
- I think that modified version will be 0.3

# Bug : What is the problem
- we have the error when we use enum without name.
```
enum {
    AAAAAAA,
    BBBBBBB,
};
```

- Error Message
```
[1133] WARN-enum: nameless enum ['enum', '{', 'AAAAAAA', ',', 'BBBBBBB', ',', '}']
Traceback (most recent call last):
  File "/Users/cheoljoo/.local/bin/hpp2plantuml", line 11, in <module>
    load_entry_point('hpp2plantuml==0.2', 'console_scripts', 'hpp2plantuml')()
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 1110, in main
    CreatePlantUMLFile(args.input_files, args.output_file)
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 1080, in CreatePlantUMLFile
    diag.create_from_file_list(list(set(expand_file_list(file_list_c))))
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 768, in create_from_file_list
    flag_build_lists=True, flag_reset=True)
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 747, in _build_helper
    self.parse_objects(single_input, build_from_single)
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 860, in parse_objects
    self._objects.append(container_handler(obj))
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 32, in <lambda>
    ['enums', lambda objs: objs, lambda obj: Enum(obj)]
  File "/Users/cheoljoo/.local/lib/python3.6/site-packages/hpp2plantuml-0.2-py3.6.egg/hpp2plantuml/hpp2plantuml.py", line 486, in __init__
    super().__init__('enum', header_enum['name'])
KeyError: 'name'
```

- Changed Code
	- This error generates when it is not defined the key of dictionary.
		- So define "empty" name as a default value when enum does not have the name.
	- super().__init__('enum', header_enum['name']) -> super().__init__('enum', header_enum.get('name',empty))
	- output
```
@startuml
enum empty {
	AAAAAAA
	BBBBBBB
}

@enduml
```