### PR TITLE
return class name if namespace is empty

### DIFF
--- a/src/hpp2plantuml/hpp2plantuml.py
+++ b/src/hpp2plantuml/hpp2plantuml.py
@@ -641,6 +641,8 @@ class ClassRelationship(object):
         str
             Class name with appropriate prefix for use with link rendering
         """
+        if (class_namespace == ''):
+            return class_name
         return get_namespace_link_name(class_namespace) + '.' + class_name
 
     def render(self):


### PR DESCRIPTION
To avoid the added "." in front of class names in no namespace i have included this condition that checks if the namespace is empty.